### PR TITLE
Fixed example wich causes Lovelace not to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ entities:
 
 - Loop over lists
 ```yaml
-{% set lights = ['light.bed_light', 'light.kitchen_lights', 'light.ceiling_lights' %}
+{% set lights = ['light.bed_light', 'light.kitchen_lights', 'light.ceiling_lights'] %}
 
 - type: entities
   entities:


### PR DESCRIPTION
There was a missing bracket in an example which can be easily overlooked and cause a lot of frustration.