### PR TITLE
fix: allow document seperator

### DIFF
--- a/custom_components/lovelace_gen/__init__.py
+++ b/custom_components/lovelace_gen/__init__.py
@@ -25,7 +25,7 @@ def load_yaml(fname, secrets = None, args={}):
     try:
         ll_gen = False
         with open(fname, encoding="utf-8") as f:
-            if f.readline().lower().startswith("# lovelace_gen"):
+            if f.readline().lower().startswith("# lovelace_gen") or f.readline().lower().startswith("# lovelace_gen"):
                 ll_gen = True
 
         if ll_gen:


### PR DESCRIPTION
This tentatively fixes not being able to parse documents that has the document start signal `---` on first line.