### PR TITLE
Disable C Loader to fix compatibility with >= 2022.7

### DIFF
--- a/custom_components/lovelace_gen/__init__.py
+++ b/custom_components/lovelace_gen/__init__.py
@@ -64,6 +64,8 @@ def _uncache_file(ldr, node):
     return f"{path}?{timestamp}"
 
 loader.load_yaml = load_yaml
+if loader.HAS_C_LOADER:
+    loader.HAS_C_LOADER = False
 loader.SafeLineLoader.add_constructor("!include", _include_yaml)
 loader.SafeLineLoader.add_constructor("!file", _uncache_file)
 


### PR DESCRIPTION
Fixes #40 and #39. In Home Assistant 2022.7, a new feature was released to improve performance by using the YAML Loader in C. This doesn't appear to be compatible with lovelace_gen. Disabling it fixes lovelace_gen.