### PR TITLE
load the metadata into a hass entity

### DIFF
--- a/custom_components/lovelace_gen/__init__.py
+++ b/custom_components/lovelace_gen/__init__.py
@@ -68,7 +68,9 @@ loader.PythonSafeLoader.add_constructor("!include", _include_yaml)
 loader.PythonSafeLoader.add_constructor("!file", _uncache_file)
 
 async def async_setup(hass, config):
-    llgen_config.update(config.get("lovelace_gen"));
+    conf = config.get("lovelace_gen")
+    llgen_config.update(conf)
+    hass.states.async_set("lovelace_gen.data", "loaded", conf, force_update=True)
     return True
 
 # Allow redefinition of node anchors


### PR DESCRIPTION
This pull request loads the lovelace_gen _globals metadata into a HASS entity to allow the metadata to be accessed at runtime by automations, scripts, templates, javascript, etc.

The entity created is called:

"lovelace_gen.data"

See the discussion here for examples of usage

https://github.com/thomasloven/hass-lovelace_gen/issues/57