### PR TITLE
Do not sort keys when using tojson.

### DIFF
--- a/custom_components/lovelace_gen/__init__.py
+++ b/custom_components/lovelace_gen/__init__.py
@@ -17,6 +17,8 @@ def fromjson(value):
 
 jinja = jinja2.Environment(loader=jinja2.FileSystemLoader("/"))
 
+jinja.policies['json.dumps_kwargs'] = {'sort_keys': False}
+
 jinja.filters['fromjson'] = fromjson
 
 llgen_config = {}


### PR DESCRIPTION
I am passing dicts of rooms and entities, which I want to be rendered in specific order in sub templates.

When passing dictionaries to included templates, "tojson" method is used.

However, for unknown reason, the default is to sort dictionary keys. This patch reverses the default behaviour, as sorting can be done manually, if required, however unsorting cannot be done.
